### PR TITLE
Aligned .env.example to README.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,47 @@
+HOSTNAME=musicparty.example.com
+PROTOCOL=http://
+PORT=80
+
 APP_NAME="Music Party"
-APP_ENV=local
+APP_URL=${PROTOCOL}${HOSTNAME}
+#App key should be any valid, either use php to generate this or https://generate-random.org/laravel-key-generator
 APP_KEY=
+
+
+DB_DATABASE=musicparty
+DB_USERNAME=musicparty
+#Add you own dbpassword here for security
+DB_PASSWORD=
+
+#
+PUSHER_APP_KEY=musicparty
+#Generate a new secret here using UUID4 (https://generate-random.org/uuid-generator)
+PUSHER_APP_SECRET=
+#
+MIX_PUSHER_CLIENT_HOSTNAME=${HOSTNAME}
+MIX_PUSHER_CLIENT_PORT=${PORT}
+
+#Create two new apps from spotify.
+#You will need to set the redirect uri to ${PROTOCOL}${HOSTNAME}/auth/spotify/search/redirect when you create them
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+SPOTIFY_SEARCH_CLIENT_ID=
+SPOTIFY_SEARCH_CLIENT_SECRET=
+#UI required for this, available in debug output, will fall back to SPOTIFY_CLIENT_ID if not set
+SPOTIFY_SEARCH_REFRESH_TOKEN=
+
+#Create a new discord app at https://discord.com/developers/applications
+#Set the redirect uri in the OAuth2 settings to ${PROTOCOL}${HOSTNAME}/auth/discord/search/redirect
+DISCORD_CLIENT_ID=
+#OAuth2 Secret from the OAuth2 settings in Discord
+DISCORD_CLIENT_SECRET=
+
+
+#Additional env's below
+
+APP_ENV=local
 APP_DEBUG=true
-APP_URL=http://localhost:8000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
@@ -11,9 +50,6 @@ LOG_LEVEL=debug
 DB_CONNECTION=mysql
 DB_HOST=db
 DB_PORT=3306
-DB_DATABASE=musicparty
-DB_USERNAME=musicparty
-DB_PASSWORD=musicparty
 
 BROADCAST_DRIVER=pusher
 CACHE_DRIVER=redis
@@ -29,23 +65,13 @@ REDIS_PASSWORD=null
 REDIS_PORT=6379
 
 PUSHER_APP_ID=musicparty
-PUSHER_APP_KEY=musicparty
-PUSHER_APP_SECRET=musicparty
 PUSHER_APP_CLUSTER=mt1
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
-MIX_PUSHER_CLIENT_HOSTNAME=localhost
-MIX_PUSHER_CLIENT_PORT=6001
 
-SPOTIFY_CLIENT_ID=
-SPOTIFY_CLIENT_SECRET=
 SPOTIFY_REDIRECT_URI="${APP_URL}/auth/spotify/redirect"
 
-SPOTIFY_SEARCH_CLIENT_ID=
-SPOTIFY_SEARCH_CLIENT_SECRET=
 SPOTIFY_SEARCH_REDIRECT_URI="${APP_URL}/auth/spotify/search/redirect"
 
-DISCORD_CLIENT_ID=
-DISCORD_CLIENT_SECRET=
 DISCORD_REDIRECT_URI="${APP_URL}/auth/discord/redirect"


### PR DESCRIPTION
A few changes and example documentation in the README have not been ported into the .env.example file. This PR resolves this