### PR TITLE
Discord OAuth2 Redirect is incorrect in the Readme & .env Example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ SPOTIFY_SEARCH_CLIENT_SECRET=
 SPOTIFY_SEARCH_REFRESH_TOKEN=
 
 #Create a new discord app at https://discord.com/developers/applications
-#Set the redirect uri in the OAuth2 settings to ${PROTOCOL}${FQDN}/auth/discord/search/redirect
+#Set the redirect uri in the OAuth2 settings to ${PROTOCOL}${FQDN}/auth/discord/redirect
 DISCORD_CLIENT_ID=
 #OAuth2 Secret from the OAuth2 settings in Discord
 DISCORD_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SPOTIFY_SEARCH_REDIRECT_URI=${APP_URL}/auth/spotify/search/redirect
 SPOTIFY_SEARCH_REFRESH_TOKEN=
 
 #Create a new discord app at https://discord.com/developers/applications
-#Set the redirect uri in the OAuth2 settings to ${PROTOCOL}${FQDN}/auth/discord/search/redirect
+#Set the redirect uri in the OAuth2 settings to ${PROTOCOL}${FQDN}/auth/discord/redirect
 DISCORD_CLIENT_ID=
 #OAuth2 Secret from the OAuth2 settings in Discord
 DISCORD_CLIENT_SECRET=


### PR DESCRIPTION
Discord OAuth2 Redirect is incorrect in the Readme & .env Example