### PR TITLE
Improve display of vote count and song length

### DIFF
--- a/resources/js/components/Upcoming.vue
+++ b/resources/js/components/Upcoming.vue
@@ -22,14 +22,14 @@
                             <div class="col-auto text-center">
                                 <div class="row">
                                     <template v-if="can_downvote == 1">
-                                        <div class="col-4">
+                                        <div class="col-3">
                                             <i v-if="song.vote <= 0" class="icon ti ti-arrow-big-up cursor-pointer" @click="vote(song.id, 1)"></i>
                                             <i v-if="song.vote === 1" class="icon ti ti-arrow-big-up-filled cursor-pointer text-success" @click="vote(song.id, 0)"></i>
                                         </div>
-                                        <div class="col-4">
+                                        <div class="col-6">
                                             {{ song.score }}
                                         </div>
-                                        <div class="col-4">
+                                        <div class="col-3">
                                             <i v-if="song.vote >= 0" class="icon ti ti-arrow-big-down cursor-pointer" @click="vote(song.id, -1)"></i>
                                             <i v-if="song.vote === -1" class="icon ti ti-arrow-big-down-filled cursor-pointer text-danger" @click="vote(song.id, 0)"></i>
                                         </div>

--- a/resources/js/components/Upcoming.vue
+++ b/resources/js/components/Upcoming.vue
@@ -18,7 +18,7 @@
                                     <template v-else>Fallback Track</template>
                                 </div>
                             </div>
-                            <div class="col-auto text-secondary">{{ formatMs(song.length) }}</div>
+                            <div class="col-auto text-secondary song-length">{{ formatMs(song.length) }}</div>
                             <div class="col-auto text-center">
                                 <div class="row">
                                     <template v-if="can_downvote == 1">
@@ -81,7 +81,6 @@
     </div>
 </template>
 <style>
-
     .list-move,
     .list-enter-active,
     .list-leave-active {
@@ -93,8 +92,13 @@
         opacity: 0;
         transform: translateX(30px);
     }
+
     .list-leave-active {
         position: absolute;
+    }
+
+    .song-length {
+        padding-right: 1rem;
     }
 </style>
 <script>


### PR DESCRIPTION
Adjusted columns to fix display of double-digit negatives (#27), and added a little extra padding for separation of song length.

![image](https://github.com/mintopia/musicparty/assets/55830/f6c02d51-d3e9-4e9a-a74b-1ce590bc1689)
