### PR TITLE
Add minimum song length rule

### DIFF
--- a/app/Http/Controllers/PartyController.php
+++ b/app/Http/Controllers/PartyController.php
@@ -146,6 +146,9 @@ class PartyController extends Controller
         } else {
             $party->downvotes_per_hour = null;
         }
+        if ($request->has('min_song_length') && $request->input('min_song_length') > 0) {
+            $party->min_song_length = $request->input('min_song_length');
+        }
         if ($request->has('max_song_length') && $request->input('max_song_length') > 0) {
             $party->max_song_length = $request->input('max_song_length');
         }

--- a/app/Http/Requests/PartyRequest.php
+++ b/app/Http/Requests/PartyRequest.php
@@ -51,6 +51,7 @@ class PartyRequest extends FormRequest
                 'nullable',
                 'string',
             ],
+            'min_song_length' => 'sometimes|integer|min:1|nullable',
             'max_song_length' => 'sometimes|integer|min:1|nullable',
             'no_repeat_interval' => 'sometimes|integer|min:1|nullable'
         ];

--- a/app/Services/RequestCheckService.php
+++ b/app/Services/RequestCheckService.php
@@ -106,6 +106,9 @@ class RequestCheckService
             return new RequestCheckResponse(false, 'You are not allowed to make requests');
         }
 
+        if ($this->party->min_song_length && ($spotifyData->duration_ms / 1000) < $this->party->min_song_length) {
+            return new RequestCheckResponse(false, 'Song is too short');
+        }
         if ($this->party->max_song_length && ($spotifyData->duration_ms / 1000) > $this->party->max_song_length) {
             return new RequestCheckResponse(false, 'Song is too long');
         }

--- a/database/migrations/2024_10_12_194751_add_min_song_length_to_parties.php
+++ b/database/migrations/2024_10_12_194751_add_min_song_length_to_parties.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('parties', function (Blueprint $table) {
+            $table->integer('min_song_length')->nullable()->default(null)->after('downvotes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('parties', function (Blueprint $table) {
+            $table->dropColumn('min_song_length');
+        });
+    }
+};

--- a/resources/views/parties/_form.blade.php
+++ b/resources/views/parties/_form.blade.php
@@ -77,6 +77,18 @@
 
         <div class="mb-3 row">
             <div class="mb-3 col-md-6">
+                <label class="form-label">Minimum Song Length</label>
+                <div class="input-group">
+                    <input type="text" name="min_song_length" class="form-control @error('min_song_length') is-invalid @enderror"
+                           value="{{ old('min_song_length', $party->min_song_length ?? '') }}">
+                    <span class="input-group-text">seconds</span>
+                </div>
+                <small class="form-hint">The minimum length a requested song can be</small>
+                @error('min_song_length')
+                <p class="invalid-feedback">{{ $message }}</p>
+                @enderror
+            </div>
+            <div class="mb-3 col-md-6">
                 <label class="form-label">Maximum Song Length</label>
                 <div class="input-group">
                     <input type="text" name="max_song_length" class="form-control @error('max_song_length') is-invalid @enderror"


### PR DESCRIPTION
We had issues with overly short tracks in the queue and the spotify API polling being too long to keep up when they're playing.
I figured the easiest thing would be to prohibit songs less than a minute long.